### PR TITLE
Use escapeXML instead of manual string replacement in trivy JUnit template

### DIFF
--- a/contrib/junit.tpl
+++ b/contrib/junit.tpl
@@ -9,7 +9,7 @@
         </properties>
         {{- end -}}
         {{ range .Vulnerabilities }}
-        <testcase classname="{{ .PkgName | replace "/" "." }}-{{ .InstalledVersion }}" file="{{ .PkgName }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
+        <testcase classname="{{ escapeXML .PkgName }}-{{ .InstalledVersion }}" file="{{ .PkgName }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
           <failure message="{{ escapeXML .Title }}" type="description">
             Severity: {{ .Severity }}
             Package Path (if available): {{ .PkgPath }}


### PR DESCRIPTION
## Description

We want to add the template upstream, so using standard escaping instead of manual replacements.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
