### PR TITLE
[ENGPROD-6654] Ignore policies from a folder

### DIFF
--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -66,7 +66,7 @@ var (
 		Name:       "ignore-policy",
 		ConfigName: "ignore-policy",
 		Default:    "",
-		Usage:      "specify the Rego file path to evaluate each vulnerability",
+		Usage:      "specify the Rego file path (or dir path with Rego files) to evaluate each vulnerability",
 	}
 	ExitCodeFlag = Flag{
 		Name:       "exit-code",


### PR DESCRIPTION
## Description

Adjusted the `--ignore-policy` option to also support reading the *.rego policies files from a folder.

```bash
> trivy image -h
...
Report Flags
  ...
  -f, --format string              format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
      --ignore-policy string       specify the Rego file path (or dir path with Rego files) to evaluate each vulnerability
  ...
```

The change is backward compatible. As usual, the `--ignore-policy ignore.rego` option can be used.
If the option value is a filesystem directory it will recursively search for *.rego files in it and apply each found one to the scan results.
```bash
> ./trivy image --ignore-policy /path/to/folder/with/regos image_to_scan
```

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
