### PR TITLE
[PRDSEC-929] datarobot goreleaser file changed with actual links

### DIFF
--- a/goreleaser-datarobot.yml
+++ b/goreleaser-datarobot.yml
@@ -1,12 +1,14 @@
+version: 2
+
 project_name: trivy
 builds:
   - id: build-linux
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X github.com/aquasecurity/trivy/pkg/version.ver={{.Version}}
+      - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,12 +21,12 @@ builds:
     goarm:
       - 7
   - id: build-macos
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X github.com/aquasecurity/trivy/pkg/version.ver={{.Version}}
+      - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -53,7 +55,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
       - "--platform=linux/amd64"
     extra_files:
     - contrib/
@@ -74,7 +76,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
       - "--platform=linux/arm64"
     extra_files:
     - contrib/


### PR DESCRIPTION
## Description
attempt to actualise goreleaser-datarobot.yaml

build was successful  
<img width="327" height="64" alt="Screenshot 2025-10-08 at 16 02 33" src="https://github.com/user-attachments/assets/ee1eab14-9b75-4c4a-829a-1264d41ef4a7" />


